### PR TITLE
Default to tabindex 0

### DIFF
--- a/examples/src/components/PaperStack/PaperStackItem.html
+++ b/examples/src/components/PaperStack/PaperStackItem.html
@@ -5,7 +5,7 @@
   {% set classes = (classes.push(options.classes | join(' ')) if options.classes, classes) %}
   {% set classes = classes | join(' ') | trim %}
 
-  {% set tabIndex = 'tabindex="1"' if options.draggable %}
+  {% set tabIndex = 'tabindex="0"' if options.draggable %}
 
   <li class="{{ classes }}" {{ tabIndex | safe }}>
     <div class="PaperStackContent">

--- a/examples/src/components/StackedList/StackedListItem.html
+++ b/examples/src/components/StackedList/StackedListItem.html
@@ -5,7 +5,7 @@
   {% set classes = (classes.push(options.classes | join(' ')) if options.classes, classes) %}
   {% set classes = classes | join(' ') | trim %}
 
-  {% set tabIndex = 'tabindex="1"' if options.draggable %}
+  {% set tabIndex = 'tabindex="0"' if options.draggable %}
   {% set iconClass = 'DragHandle' if options.draggable else 'NopeHandle' %}
 
   <li class="{{ classes }}" {{ tabIndex | safe }}>


### PR DESCRIPTION
`tabindex` should default to 0 in the example. Why? Because defaulting to `1` causes unexpected keyboard behavior, which leads to the mistaken perception that the library is less accessible.

### Expected

In the "Sortable" and "Transformed" examples, I expect to be able to tab from the top of the browser, down the the sortable/transformed items in a manner the fits my expectation on proper tab order. For example, I expect to go from the Chrome tab to the first focusable item (probably something in the main navigation), then after tabbing to the main context area, I expect to be able to tab to the example sortable/transformed items.

### Actually

Coming from the browser Chrome, the sortable/transformed items are the first things to be focused via keyboard tab, instead of anything else on the page. This is confusing for keyboard users.